### PR TITLE
Use default state 'restarted' to restart existing services

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ beszel_service_enabled: true
 Enable the Beszel binary agent systemd service on boot.
 
 ```yaml
-beszel_service_state: started
+beszel_service_state: restarted
 ```
 
 State of the Beszel binary agent systemd service.
@@ -81,3 +81,5 @@ This role depends on a precompiled binary published on GitHub at [henrygd/beszel
 ## Contributors
 
 [dbrennand](https://github.com/dbrennand)
+
+[stegmatze](https://github.com/stegmatze)

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ This role depends on a precompiled binary published on GitHub at [henrygd/beszel
 
 ## License 📝
 
-[LICENSE](LICENSE).
+[LICENSE](LICENSE)
 
 ## Contributors
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,4 +20,4 @@ beszel_args: ""
 # Enable the Beszel binary agent systemd service on boot
 beszel_service_enabled: true
 # State of the Beszel binary agent systemd service
-beszel_service_state: started
+beszel_service_state: restarted


### PR DESCRIPTION
Use default state 'restarted' to restart existing services when updating the agent.

If the service is not running, it will still be started.

Fixes #2 