### PR TITLE
1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ beszel_service_enabled: true
 Enable the Beszel binary agent systemd service on boot.
 
 ```yaml
-beszel_service_state: restarted
+beszel_service_state: started
 ```
 
 State of the Beszel binary agent systemd service.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,4 +20,4 @@ beszel_args: ""
 # Enable the Beszel binary agent systemd service on boot
 beszel_service_enabled: true
 # State of the Beszel binary agent systemd service
-beszel_service_state: restarted
+beszel_service_state: started

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,3 +3,8 @@
 - name: Reload systemd configuration
   ansible.builtin.systemd_service:
     daemon_reload: true
+
+- name: Restart Beszel binary agent systemd service
+  ansible.builtin.service:
+    name: beszel-agent
+    state: restarted

--- a/tasks/beszel_present.yml
+++ b/tasks/beszel_present.yml
@@ -20,11 +20,18 @@
 
 - name: beszel_present | Download Beszel binary agent tarball
   ansible.builtin.get_url:
-    url: "https://github.com/henrygd/beszel/releases/{{ beszel_version }}/download/beszel-agent_linux_{{ beszel_architecture | trim }}.tar.gz" # noqa yaml[line-length]
+    url: |
+      {% if beszel_version == 'latest' %}
+        https://github.com/henrygd/beszel/releases/{{ beszel_version }}/download/beszel-agent_linux_{{ beszel_architecture | trim }}.tar.gz
+      {% else %}
+        https://github.com/henrygd/beszel/releases/download/{{ beszel_version }}/beszel-agent_linux_{{ beszel_architecture | trim }}.tar.gz
+      {% endif %}
     dest: /tmp/beszel-agent.tar.gz
+    force: true
     mode: u=rw,g=,o=
 
 - name: beszel_present | Extract Beszel binary agent tarball
+  notify: Restart Beszel binary agent systemd service
   ansible.builtin.unarchive:
     src: /tmp/beszel-agent.tar.gz
     dest: "{{ beszel_install_dir }}"


### PR DESCRIPTION
# 1.2.0

- Resolves #4 
- Backwards compatibility for issue #2. Using a handler instead when the version is changed instead of defaulting to `restarted`.
- Fixes an issue caught during testing where specifying a specific version wasn't downloading the tarball correctly.